### PR TITLE
fix generate yandex categories

### DIFF
--- a/src/schemas/category.clj
+++ b/src/schemas/category.clj
@@ -8,9 +8,9 @@
    :ancestry (s/maybe s/Str)})
 
 (defn DBCategory->Category
-  [{:keys [id name ancestry]}]
+  [{:keys [id cached_title ancestry]}]
   {:id id
-   :name name
+   :name cached_title
    :ancestry ancestry})
 
 (def DBCategory->Category-coercer


### PR DESCRIPTION
сахарок воспользовался яндекс маркетом, выяснилось что тег category пустой. проблема в том что в коде ожидается наличие поля name у categories, но его там нету.

https://yadi.sk/i/Rz5yN5cbr2bFp
